### PR TITLE
test.Maps() and test.Panic() refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,205 @@
 
 # blugnu/test
 
-TODO: documentation is coming, for now please refer to the go docs
+Provides some simple test helpers for use with the standard library testing package.  It is not a replacement for the testing package or complete testing framework.
+
+## Features
+
+- [x] Test comparable values (e.g. `[]byte`, `map[]`)
+- [x] Capture console output
+- [x] Test console output
+- [x] Test test helpers
+- [x] Test for expected panics
+
+## Installation
+
+```bash
+go get github.com/blugnu/test
+```
+
+## Examples
+
+- [Test for Unexpected Errors and Equality of Comparable Values](#test-for-unexpected-errors-and-equality-of-comparable-values)
+- [Testing `map` and `[]byte`](#testing-maps-and-byte-slices)
+- [Capture and Test Console Output](#capture-and-test-console-output)
+- [Testing a Test Helper](#testing-a-test-helper)
+- [Test for Expected Panics](#test-for-expected-panics)
+- [Test for an Expected Type](#test-for-an-expected-type)
+
+
+### Test for Unexpected Errors and Equality of Comparable Values
+
+If a test is not expected to return an error you can use the `test.UnexpectedError` function to test for this.  Similarly, if a test is expected to return a specific value you can use the `test.Equals` function to test for this.  The `test.Equals` function can be used to test for equality of any comparable value.
+
+```go
+func TestDoSomething(t *testing.T) {
+  // ACT
+  got, err := DoSomething()
+
+  // ASSERT
+  test.UnexpectedError(t, err)
+  test.Equal(t, "foo", got)
+}
+```
+
+To test for a specific error you can use the `test.ErrorIs` function:
+
+```go
+func TestDoSomething(t *testing.T) {
+  // ACT
+  err := DoSomething()
+
+  // ASSERT
+  test.ErrorIs(t, ErrSomething, err)
+}
+```
+
+An optional argument may be used to specify the format of the expected and actual values in any test failure report produced by `test.Equal()`.  The default format is `FormatDefault`:
+
+```go
+func TestDoSomething(t *testing.T) {
+  // ARRANGE
+  expected := "foo"
+  got := "bar"
+
+  // ACT & ASSERT
+  test.Equal(t, expected, got)               // displays values in a failure as default (%v)
+  test.Equal(t, expected, got, FormatHex)    // displays values in a failure as hexadecimal
+}
+```
+
+Any format may be specified by casting a string as a `Format` if needed; sensible values are provided as constants.
+
+### Testing Maps and Byte Slices
+
+```go
+func TestDoSomething(t *testing.T) {
+  // ARRANGE
+  expected := map[string]string{
+    "foo": "bar",
+  }
+
+  // ACT
+  got := DoSomething()
+
+  // ASSERT
+  test.Maps(t, expected, got)
+}
+```
+
+When testing `[]byte`, an optional format argument may be used to specify the format of the expected and actual values in any test failure report.  The default format is `BytesHex` (hexadecimal):
+
+```go
+func TestDoSomething(t *testing.T) {
+  // ARRANGE
+  expected := []byte("foo")
+  got := []byte("bar")
+
+  // ACT & ASSERT
+  test.Bytes(t, expected, got)               // displays values in a failure as hexadecimal
+  test.Bytes(t, expected, got, BytesBinary)  // displays values in a failure as binary
+}
+```
+
+Any format may be specified by casting a string as a `BytesFormat` if needed; sensible values are provided as constants.
+
+
+### Capture and Test Console Output
+
+```go
+func TestDoSomething(t *testing.T) {
+  // ARRANGE
+  var err error
+
+  // ACT - discards stderr and result of DoSomething
+  stdout, _ := test.CaptureOutput(t, func (*testing.T) {
+    _, err := DoSomething()
+    return err
+  })
+
+  // ASSERT
+  test.UnexpectedError(t, err)
+  test.Equals(t, "foo", got)
+  stdout.Contains("some expected log message")
+}
+```
+
+### Testing a Test Helper
+
+The `test.Helper` function combines the execution of a test helper with the testing of the outcome of the helper.  The outcome of the helper is specific using `test.ShouldPass` or `test.ShouldFail` or providing a `test.*Panic` if the helper is expected to panic.
+
+The output of the test helper is returned as `CapturedOutput` (both `stdout` and `stderr`) so that the presentation of test failure messages in the log can also be tested and verified. 
+
+```go
+func TestUnexpectedError(t *testing.T) {
+  // ARRANGE
+  err := errors.New("some error")
+
+  // ACT & ASSERT
+  stdout, stderr := test.Helper(t, func(st *testing.T) {
+    test.UnexpectedError(st, err)
+  }, test.ShouldPass)
+
+  stdout.Contains(nil)  // no output expected for a PASS
+}
+```
+
+> **NOTE:** _It is important that the helper function being tested is called with the `*testing.T` passed to the function that runs it (`st` in the example above) and not the `T` of the test (`t` in the example)._
+
+### Test for Expected Panics
+
+Panic tests must be deferred to ensure that the panic is captured and tested.  The `test.ExpectPanic` function returns a `*Panic` value with an `IsRecovered` function that can be deferred to test for an expected panic.
+
+```go
+func TestDoSomething(t *testing.T) {
+  // ARRANGE
+  err := errors.New("some error")
+  defer test.ExpectPanic(err).IsRecovered(t)
+
+  // ACT
+  panic(err)
+}
+```
+
+The `IsRecovered` function may be called on a `nil` receiver to test that no panic was recovered, which is useful in table-driven tests:
+
+```go
+func TestDoSomething(t *testing.T) {
+  // ARRANGE
+  err := errors.New("panicked")
+
+  testcases := []struct {
+    name string
+    error
+    panic  *test.Panic
+  }{
+    {name: "panic expected", error: err, panic: test.ExpectPanic(err)},
+    {name: "no panic expected", err: nil},
+  }
+  for _, tc := range testcases {
+    t.Run(tc.name, func(t *testing.T) {
+      // ARRANGE
+      defer tc.panic.IsRecovered(t)
+
+      // ACT
+      panic(tc.error)
+    })
+  }
+}
+```
+
+## Test for an Expected Type
+
+You can test that some value is of an expected type using the `test.Type` function.  This function returns the value as the expected type if the test passes, otherwise it returns `nil` and the test fails. If the value is of the expected type, further tests may then be performed on the returned value as that type:
+
+```go
+func TestDoSomething(t *testing.T) {
+  // ACT
+  result := DoSomething()
+
+  // ASSERT
+  if got, ok := test.Type[Customer](t, result); ok {
+    // further assertions on got (of type Customer)
+  }
+}
+```

--- a/helper.go
+++ b/helper.go
@@ -12,13 +12,16 @@ type HelperResult bool
 const ShouldPass HelperResult = true
 const ShouldFail HelperResult = false
 
-// Helper runs a test helper function and compares the result to an
+// runs a test helper function and compares the result to an
 // expected outcome.  The expected outcome (want) must be ONE of
 // the following:
 //
 //   - test.ShouldPass
 //   - test.ShouldFail
-//   - *test.ExpectedPanic (see: test.Panic())
+//   - *test.Panic (see: test.ExpectPanic())
+//
+// The function returns `stdout` and `stderr` output captured
+// while the helper function is executed.
 //
 // Example:
 //
@@ -47,7 +50,7 @@ func Helper(t *testing.T, f func(st *testing.T), want any) (CapturedOutput, Capt
 		result = expected
 	case HelperResult:
 		result = bool(expected)
-	case *ExpectedPanic:
+	case *Panic:
 		err = expected.error
 	case nil: // no outcome specified
 		checkresult = false

--- a/helper_test.go
+++ b/helper_test.go
@@ -23,10 +23,10 @@ func TestHelper(t *testing.T) {
 	}
 	testcases := []struct {
 		name    string
-		args                   // args passed to the Helper() function under test
-		outcome any            // expected outcome of the Helper() used to test Helper()
-		panic   *ExpectedPanic // expected panic, if any
-		output  any            // expected output
+		args           // args passed to the Helper() function under test
+		outcome any    // expected outcome of the Helper() used to test Helper()
+		panic   *Panic // expected panic, if any
+		output  any    // expected output
 	}{
 		{name: "invalid outcome", args: args{func(st *testing.T) {}, 42}, outcome: ExpectPanic(ErrInvalidArgument)},
 		{name: "fail, no outcome", args: args{fn: func(st *testing.T) { st.Fail() }}, outcome: ShouldPass},
@@ -82,7 +82,7 @@ func TestHelper(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			// ARRANGE
-			defer tc.panic.Assert(t)
+			defer tc.panic.IsRecovered(t)
 
 			// HERE BE DRAGONS: the Helper test is used to test the Helper test
 			// (and capture the output from it)

--- a/maps.go
+++ b/maps.go
@@ -1,0 +1,38 @@
+package test
+
+import "testing"
+
+// compares two maps and fails the test if they are not equal.
+//
+// Example:
+//
+//	  func TestSomething(t *testing.T) {
+//		// ARRANGE
+//		want := map[string]int{"a": 1, "b": 2}
+//		got := map[string]int{"a": 1, "b": 2}
+//
+//		// ASSERT
+//		test.Maps(t, want, got)
+//	  }
+func Maps[K comparable, V comparable](t *testing.T, want, got map[K]V) (keys []K, values []V) {
+	t.Helper()
+
+	ok := len(want) == len(got)
+	if ok {
+		wk := make([]K, 0, len(want))
+		for k := range want {
+			wk = append(wk, k)
+		}
+		for _, k := range wk {
+			if ok = want[k] == got[k]; !ok {
+				break
+			}
+		}
+	}
+
+	if !ok {
+		t.Errorf("\nwanted: %#v\ngot    : %#v", want, got)
+	}
+
+	return
+}

--- a/maps_test.go
+++ b/maps_test.go
@@ -1,0 +1,32 @@
+package test
+
+import "testing"
+
+func TestMaps(t *testing.T) {
+	// ARRANGE
+	testcases := []struct {
+		name    string
+		want    map[string]int
+		got     map[string]int
+		outcome HelperResult
+	}{
+		{name: "same keys and values",
+			want:    map[string]int{"a": 1, "b": 2},
+			got:     map[string]int{"a": 1, "b": 2},
+			outcome: ShouldPass,
+		},
+		{name: "same keys different values",
+			want:    map[string]int{"a": 1, "b": 2},
+			got:     map[string]int{"a": 2, "b": 1},
+			outcome: ShouldFail,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			// ACT & ASSERT
+			Helper(t, func(st *testing.T) {
+				Maps(st, tc.want, tc.got)
+			}, tc.outcome)
+		})
+	}
+}

--- a/panic.go
+++ b/panic.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 )
 
-// ExpectedPanic is used to test for panics.
-type ExpectedPanic struct {
+// Panic is used to test for panics.
+type Panic struct {
 	error
 }
 
-// Assert fails the test if the expected panic does not occur.
+// IsRecovered fails the test if the expected panic does not occur.
 //
 // The test will pass if:
 //
@@ -19,24 +19,24 @@ type ExpectedPanic struct {
 //     that satisfies errors.Is() with respect to the expected error
 //
 // Panics are tested by arranging an ExpectedPanic and then deferring
-// a call to Assert() in the test function.
+// a call to IsRecovered() in the test function.
 //
 // Example:
 //
 //	  func TestSomething(t *testing.T) {
 //		// ARRANGE
-//		defer test.ExpectPanic(err).Assert(t)
+//		defer test.ExpectPanic(err).IsRecovered(t)
 //
 //		// ACT
 //		doSomething()
 //	  }
 //
-// Assert may be called on a nil receiver and is equivalent to
-// calling Assert() on an ExpectedPanic with a nil error. This
+// IsRecovered may be called on a nil receiver and is equivalent to
+// calling IsRecovered() on a *Panic with a nil error. This
 // simplifies panic tests in data-driven tests where the expected
 // panic may be nil for some test cases (indicating no panic is
 // expected).
-func (e *ExpectedPanic) Assert(t *testing.T) {
+func (e *Panic) IsRecovered(t *testing.T) {
 	t.Helper()
 
 	r := recover()
@@ -55,7 +55,25 @@ func (e *ExpectedPanic) Assert(t *testing.T) {
 	}
 }
 
-// ExpectPanic returns an ExpectedPanic that can be used to test for panics.
-func ExpectPanic(err error) *ExpectedPanic {
-	return &ExpectedPanic{err}
+// ExpectPanic returns a *Panic that can be used to test that an expected
+// panic occured and recovered a specified error.
+//
+// The same test can be used to verify that no panic occured, by calling
+// the IsRecovered(t) method on a nil *Panic or passing nil as the error
+// argument to ExpectPanic (which will then return a nil *Panic).
+//
+// Example:
+//
+//	  func TestSomething(t *testing.T) {
+//		// ARRANGE
+//		defer test.ExpectPanic(err).IsRecovered(t)
+//
+//		// ACT
+//		doSomething()
+//	  }
+func ExpectPanic(err error) *Panic {
+	if err == nil {
+		return nil
+	}
+	return &Panic{err}
 }


### PR DESCRIPTION
- introduces a new test helper for testing maps with comparable keys and values: test.Maps()
- renames the test helper function and type for testing panics, to improve readability of tests that use this helper
- added documentation to the README, including a number of basic examples
