### PR TITLE
mocks and fakes

### DIFF
--- a/expectationsWereMet.go
+++ b/expectationsWereMet.go
@@ -1,0 +1,74 @@
+package test
+
+import "testing"
+
+// Mock is an interface describing the methods required to be supported by a
+// mock that can be tested using test.MockExpectations().
+type Mock interface {
+	ExpectationsWereMet() error
+	Resetter
+}
+
+// ExpectationsWereMet is a convenience function for testing and resetting mocks.
+// It verifies that all expectations set on the mocks have been met and resets
+// the mocks to their initial state.  If any expectations were not met an error
+// is reported.  All mocks are tested, even if some mocks have failed to meet
+// their expectations.
+//
+// It is recommended that the test function should call this function using the
+// defer statement to ensure that the mocks are tested and reset after the test
+// function completes.
+//
+// This function support mocks that implement the test.Mock interface:
+//
+//	type Mock interface {
+//		ExpectationsWereMet() error
+//		Resetter
+//	}
+//
+//	type Resetter interface {
+//		Reset()
+//	}
+//
+// The Resetter interface is used to reset the mocks to their initial state and
+// is also used to support resetting fakes (see: test.Fake[R]).  A mock is always
+// reset after expectations have been tested, regardless of whether the test
+// passed or failed.
+//
+// Where a mock is used to provide a more complex fake implementation of an
+// interface but details (i.e. expectations) of how the interface is used are not
+// of interest to this test, the Resetter interface can be used to reset the
+// mock without testing the expectations.
+//
+// # Example
+//
+//	func TestSomething(t *testing.T) {
+//		// ARRANGE
+//		mock1 := NewMock()
+//		mock2 := NewMock()
+//		defer test.ExpectationsWereMet(t, mock1, mock2)
+//
+//		// .. set expectations on mock1 and mock2
+//
+//		// ACT
+//		// .. call the code under test
+//
+//		// ASSERT
+//		// .. assertions additional to testing mock expectations (if any)
+//	}
+func ExpectationsWereMet(t *testing.T, m ...Mock) {
+	t.Helper()
+
+	// ensure that all mocks are reset after all expectations have been tested
+	defer func() {
+		for _, mock := range m {
+			mock.Reset()
+		}
+	}()
+
+	for _, mock := range m {
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Error(err)
+		}
+	}
+}

--- a/expectationsWereMet_test.go
+++ b/expectationsWereMet_test.go
@@ -1,0 +1,42 @@
+package test
+
+import (
+	"errors"
+	"testing"
+)
+
+type mockExpectationsWereMet struct {
+	ExpectationsWereMetWasCalled bool
+	ResetWasCalled               bool
+	error
+}
+
+func (mock *mockExpectationsWereMet) ExpectationsWereMet() error {
+	mock.ExpectationsWereMetWasCalled = true
+	return mock.error
+}
+
+func (mock *mockExpectationsWereMet) Reset() {
+	mock.ResetWasCalled = true
+}
+
+func TestExpectationsWereMet(t *testing.T) {
+	// ARRANGE
+	mock1 := &mockExpectationsWereMet{error: errors.New("mock1 error")}
+	mock2 := &mockExpectationsWereMet{error: errors.New("mock2 error")}
+
+	// ACT
+	test := Helper(t, func(st *testing.T) { ExpectationsWereMet(st, mock1, mock2) })
+
+	// ASSERT
+	Bool(t, mock1.ExpectationsWereMetWasCalled).IsTrue()
+	Bool(t, mock2.ExpectationsWereMetWasCalled).IsTrue()
+	Bool(t, mock1.ResetWasCalled).IsTrue()
+	Bool(t, mock2.ResetWasCalled).IsTrue()
+
+	test.DidFail()
+	test.Report.Contains([]string{
+		"mock1 error",
+		"mock2 error",
+	})
+}

--- a/fake.go
+++ b/fake.go
@@ -1,0 +1,43 @@
+package test
+
+// Fake is a generic type that can be used to fake a function call returning
+// some result type R and/or an error. It is useful for creating fakes for 
+// interface implmentations by composing an anonymous Fake[R] into a struct
+// implementing the desired method to be faked by returning the required values
+// from the Fake.
+//
+// By using an anonymous field of type Fake[R] in a struct, the Reset() method
+// of the Fake is promoted to the struct, allowing the struct to be reset to its
+// zero value. 
+//
+// When faking an interface method that returns multiple result values (in
+// addition to an error), use a struct type with fields for each of the result
+// values.
+//
+// When faking an interface method that returns only result values and no error
+// simply ignore the Err field.  To fake a method that returns only an error,
+// it is recommended to specify a result type of any and ignore the Result field.
+//
+// # Example
+//
+// 	type MyInterface interface {
+// 		MyMethod() (int, error)
+// 	}
+//
+// 	type MyFake struct {
+// 		Fake[int]
+// 	}
+//
+// 	func (f *MyFake) MyMethod() (int, error) {
+// 		return f.Result, f.Err
+// 	}
+type Fake[R any] struct {
+	Result R
+	Err error
+}
+
+// Reset sets the Result and Err fields to their zero values.
+func (f *Fake[R]) Reset() {
+	f.Result = *new(R)
+	f.Err = nil
+}

--- a/fake_test.go
+++ b/fake_test.go
@@ -1,0 +1,14 @@
+package test
+
+import "testing"
+
+func TestFake(t *testing.T) {
+	// ARRANGE
+	fake := Fake[int]{Result: 42}
+
+	// ACT
+	fake.Reset()
+
+	// ASSERT
+	That(t, fake.Result).Equals(0)
+}

--- a/reset.go
+++ b/reset.go
@@ -1,0 +1,40 @@
+package test
+
+// Resetter is an interface that describes the Reset method. A Resetter
+// is any type that can be reset to some initial state.
+type Resetter interface {
+	Reset()
+}
+
+// Reset calls the Reset method on each Resetter in the list. A Resetter
+// is any type that implements the Resetter interface:
+//
+//	type Resetter interface {
+//		Reset()
+//	}
+//
+// Reset is a convenience function for resetting multiple Resetters,
+// such as fakes and mocks.
+//
+// # Example
+//
+//	func TestSomething(t *testing.T) {
+//		// ARRANGE
+//		fake := NewFake()
+//		mock := NewMock()
+//		defer test.Reset(fake, mock)
+//
+//		// .. set expectations on mock
+//
+//		// ACT
+//		// .. call the code under test
+//
+//		// ASSERT
+//		// .. assertions additional to testing mock expectations (if any)
+//		test.MockExpectations(t, mock)
+//	}
+func Reset(r ...Resetter) {
+	for _, resetter := range r {
+		resetter.Reset()
+	}
+}

--- a/reset_test.go
+++ b/reset_test.go
@@ -1,0 +1,28 @@
+package test
+
+import "testing"
+
+type resettableInt int
+
+func (r *resettableInt) Reset() {
+	*r = 0
+}
+
+type resettableString string
+
+func (r *resettableString) Reset() {
+	*r = ""
+}
+
+func TestReset(t *testing.T) {
+	// ARRANGE
+	var i resettableInt = 42
+	var s resettableString = "hello"
+
+	// ACT
+	Reset(&i, &s)
+
+	// ASSERT
+	That(t, i).Equals(0)
+	That(t, s).Equals("")
+}

--- a/strings.go
+++ b/strings.go
@@ -14,11 +14,24 @@ type StringsTest struct {
 // creates a testable []string value.  Options of the following types are accepted:
 //
 //	string              // a name for the test; if not specified, "strings" is used
-func Strings(t *testing.T, got []string, opts ...any) StringsTest {
+func Strings(t *testing.T, got any, opts ...any) StringsTest {
 	n := "strings"
 	checkOptTypes(t, optTypes(n), opts...)
 	getOpt(&n, opts...)
-	return StringsTest{newTestable(t, got, n)}
+
+	var sut []string
+	switch got := got.(type) {
+	case []string:
+		sut = got
+	case string:
+		sut = []string{got}
+	case []byte:
+		sut = strings.Split(string(got), "\n")
+	default:
+		panic(ErrInvalidArgument)
+	}
+
+	return StringsTest{newTestable(t, sut, n)}
 }
 
 // fails the test if the []string does not contain the wanted string

--- a/strings_test.go
+++ b/strings_test.go
@@ -4,7 +4,63 @@ import (
 	"testing"
 )
 
-func TestStringsTest(t *testing.T) {
+func TestStrings(t *testing.T) {
+	// ARRANGE
+	testcases := []struct {
+		scenario string
+		exec     func(t *testing.T)
+	}{
+		{scenario: "Strings(string)",
+			exec: func(t *testing.T) {
+				// ACT
+				result := Strings(t, "string")
+
+				// ASSERT
+				That(t, result.testable.got).Equals([]string{"string"})
+			},
+		},
+		{scenario: "Strings([]byte))",
+			exec: func(t *testing.T) {
+				// ACT
+				result := Strings(t, []byte("bytes"))
+
+				// ASSERT
+				That(t, result.testable.got).Equals([]string{"bytes"})
+			},
+		},
+		{scenario: "Strings([]string)",
+			exec: func(t *testing.T) {
+				// ACT
+				result := Strings(t, []string{"a", "b"})
+
+				// ASSERT
+				That(t, result.testable.got).Equals([]string{"a", "b"})
+			},
+		},
+		{scenario: "Strings(int)",
+			exec: func(t *testing.T) {
+				// ARRANGE
+				defer ExpectPanic(ErrInvalidArgument).Assert(t)
+
+				// ACT
+				result := Strings(t, 42)
+
+				// ASSERT
+				That(t, result.testable.got).Equals([]string{"42"})
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.scenario, func(t *testing.T) {
+			// ARRANGE
+
+			// ACT
+			tc.exec(t)
+		})
+	}
+}
+
+func TestStringsTests(t *testing.T) {
 	// ARRANGE
 	testcases := []struct {
 		scenario string


### PR DESCRIPTION
Implements the enhancements suggested in issue #1:

- new type `test.Fake[R any]` provides a fast-track to implementing test fakes
- new `test.ExpectationsWereMet()` function tests expectations on one or more mocks and resets those mocks
- new `test.Reset()` function resets one or more values implementing a `Reset` method (e.g. a fake or a mock etc)

In addition, issue #2 is also addressed, modifying the `String()` factory function to accept an `any` parameter and handling `string`, `[]string` and `[]byte` arguments which are interpreted into an appropriate `[]string` form.