### PR TITLE
String tests and test.Using helper

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,6 +1,0 @@
-name: go module release
-on: push
-jobs:
-  module-qa:
-    uses: blugnu/.reusable/.github/workflows/module.yml@master
-    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,6 @@
+name: release
+on: push
+jobs:
+  module-qa:
+    uses: blugnu/.reusable/.github/workflows/pipeline.module-release.yml@bb8b30bac311bb9edb7579799e41bd3892ff3213
+    secrets: inherit

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,3 @@
+version: 1
+build:
+  skip: true

--- a/addressOf.go
+++ b/addressOf.go
@@ -1,0 +1,30 @@
+package test
+
+// AddressOf returns the address of the value passed as argument.  If the
+// argument is a value-type variable, the address will be that of a copy
+// of the value, not the value itself.
+//
+// This function is provided for situations where a test requires that the
+// address of some value is provided; it as a convenience for the fact that
+// Golang does not allow the & operator to be used with literals or constants.
+//
+// # Example
+//
+//	func TestSomething(t *testing.T) {
+//		// given that SomeFunction returns a struct:
+//		type resultModel struct {
+//			v *string
+//		}
+//
+//		// and that SomeFunction is expected to return a resultModel with
+//		// v set to the address of a supplied string:
+//		result := SomeFunction("value")
+//
+//		// then the test could be written as:
+//		test.That(t, result).Equals(resultModel{
+//			v: test.AddressOf("value"),
+//		})
+//	}
+func AddressOf[T any](v T) *T {
+	return &v
+}

--- a/addressOf_test.go
+++ b/addressOf_test.go
@@ -1,0 +1,13 @@
+package test
+
+import (
+	"testing"
+)
+
+func TestAddressOf(t *testing.T) {
+	// ACT
+	addr := AddressOf("some literal")
+
+	// ASSERT
+	That(t, *addr).Equals("some literal")
+}

--- a/string.go
+++ b/string.go
@@ -1,0 +1,92 @@
+package test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// provides methods for testing []string values.
+type StringTest struct {
+	testable[string]
+}
+
+// creates a testable string value.  The got value being tested may be of any type
+// and will be interpreted as follows:
+//
+//	string       // a string to be tested
+//
+//	[]byte       // a byte slice containing a string to be tested
+//
+//	any          // any other type will be converted using fmt.Sprintf(%v, got)
+//	             // to the string to be tested
+//
+// In addition, options of the following types are accepted:
+//
+//	string     // a name for the test; if not specified, "string" is used
+func String(t *testing.T, got any, opts ...any) StringTest {
+	n := "string"
+	checkOptTypes(t, optTypes(n), opts...)
+	getOpt(&n, opts...)
+
+	var sut string
+	switch got := got.(type) {
+	case string:
+		sut = got
+	case []byte:
+		sut = string(got)
+	default:
+		sut = fmt.Sprintf("%v", got)
+	}
+
+	return StringTest{newTestable(t, sut, n)}
+}
+
+// Contains asserts that the string being tested contains the specified substring.
+func (c StringTest) Contains(want string) {
+	c.Helper()
+	c.Run("contains", func(t *testing.T) {
+		t.Helper()
+
+		if len(want) == 0 {
+			t.Errorf("\nContains(<empty string>) is invalid: did you mean IsEmpty()?")
+		}
+		if !strings.Contains(c.got, want) {
+			t.Errorf("\nwanted: string containing: %q\ngot   : %q", want, c.got)
+		}
+	})
+}
+
+// DoesNotContain asserts that the string being tested does not contain the
+// specified substring.
+func (c StringTest) DoesNotContain(substring string) {
+	c.Helper()
+	c.Run("does_not_contain", func(t *testing.T) {
+		t.Helper()
+
+		if len(substring) == 0 {
+			t.Errorf("\nDoesNotContain(<empty string>) is invalid test: did you mean IsNotEmpty()?")
+		}
+		if x := strings.Index(c.got, substring); x > -1 {
+			t.Errorf("\nfound: %q\nat   : %d\ngot  : %q\n        %s%s",
+				substring,
+				x,
+				c.got,
+				strings.Repeat(" ", x),
+				strings.Repeat("^", len(substring)),
+			)
+		}
+	})
+}
+
+// Equals asserts that the string being tested is equal to the specified string.
+func (c StringTest) Equals(want string) {
+	c.Helper()
+	c.Run("equals", func(t *testing.T) {
+		t.Helper()
+
+		if c.got != want {
+			t.Errorf("\nwanted: %q\ngot   : %q", want, c.got)
+		}
+	})
+}

--- a/string_test.go
+++ b/string_test.go
@@ -1,0 +1,187 @@
+package test
+
+import "testing"
+
+func TestString(t *testing.T) {
+	// ARRANGE
+	testcases := []struct {
+		scenario string
+		exec     func(t *testing.T)
+	}{
+		{scenario: "String(string)",
+			exec: func(t *testing.T) {
+				// ACT
+				result := String(t, "string")
+
+				// ASSERT
+				That(t, result.testable.got).Equals("string")
+			},
+		},
+		{scenario: "String([]byte))",
+			exec: func(t *testing.T) {
+				// ACT
+				result := String(t, []byte("bytes"))
+
+				// ASSERT
+				That(t, result.testable.got).Equals("bytes")
+			},
+		},
+		{scenario: "Strings(int)",
+			exec: func(t *testing.T) {
+				// ACT
+				result := String(t, 42)
+
+				// ASSERT
+				That(t, result.testable.got).Equals("42")
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.scenario, func(t *testing.T) {
+			tc.exec(t)
+		})
+	}
+}
+
+func TestStringTests(t *testing.T) {
+	// ARRANGE
+	testcases := []struct {
+		scenario string
+		act      func(T)
+		assert   func(HelperTest)
+	}{
+		// Contains
+		{scenario: "String(abc).Contains(<empty string>)",
+			act: func(t T) {
+				String(t, "abc").Contains("")
+			},
+			assert: func(test HelperTest) {
+				test.DidFail()
+				test.Report.Contains("String(abc).Contains(<empty_string>)/string/contains")
+				test.Report.Contains([]string{
+					`Contains(<empty string>) is invalid: did you mean IsEmpty()?`,
+				})
+			},
+		},
+		{scenario: "String(abc).Contains(a)",
+			act: func(t T) {
+				String(t, "abc").Contains("a")
+			},
+			assert: func(test HelperTest) {
+				test.DidPass()
+				test.Report.IsEmpty()
+			},
+		},
+		{scenario: "String(abc).Contains(d)",
+			act: func(t T) {
+				String(t, "abc").Contains("d")
+			},
+			assert: func(test HelperTest) {
+				test.DidFail()
+				test.Report.Contains("String(abc).Contains(d)/string/contains")
+				test.Report.Contains([]string{
+					`wanted: string containing: "d"`,
+					`got   : "abc"`,
+				})
+			},
+		},
+
+		// DoesNotContain
+		{scenario: "String(abc).DoesNotContain(<empty string>)",
+			act: func(t T) {
+				String(t, "abc").DoesNotContain("")
+			},
+			assert: func(test HelperTest) {
+				test.DidFail()
+				test.Report.Contains("String(abc).DoesNotContain(<empty_string>)/string/does_not_contain")
+				test.Report.Contains([]string{
+					`DoesNotContain(<empty string>) is invalid test: did you mean IsNotEmpty()?`,
+				})
+			},
+		},
+
+		{scenario: "String(abc).DoesNotContain(d)",
+			act: func(t T) {
+				String(t, "abc").DoesNotContain("d")
+			},
+			assert: func(test HelperTest) {
+				test.DidPass()
+				test.Report.IsEmpty()
+			},
+		},
+		{scenario: "String(abc).DoesNotContain(a)",
+			act: func(t T) {
+				String(t, "abc").DoesNotContain("a")
+			},
+			assert: func(test HelperTest) {
+				test.DidFail()
+				test.Report.Contains("String(abc).DoesNotContain(a)/string/does_not_contain")
+				test.Report.Contains([]string{
+					`found: "a"`,
+					`at   : 0`,
+					`got  : "abc"`,
+					`        ^`,
+				})
+			},
+		},
+		{scenario: "String(abc).DoesNotContain(b)",
+			act: func(t T) {
+				String(t, "abc").DoesNotContain("b")
+			},
+			assert: func(test HelperTest) {
+				test.DidFail()
+				test.Report.Contains("String(abc).DoesNotContain(b)/string/does_not_contain")
+				test.Report.Contains([]string{
+					`found: "b"`,
+					`at   : 1`,
+					`got  : "abc"`,
+					`         ^`,
+				})
+			},
+		},
+		{scenario: "String(abc).DoesNotContain(c)",
+			act: func(t T) {
+				String(t, "abc").DoesNotContain("c")
+			},
+			assert: func(test HelperTest) {
+				test.DidFail()
+				test.Report.Contains("String(abc).DoesNotContain(c)/string/does_not_contain")
+				test.Report.Contains([]string{
+					`found: "c"`,
+					`at   : 2`,
+					`got  : "abc"`,
+					`          ^`,
+				})
+			},
+		},
+
+		// Equals
+		{scenario: "String(abc).Equals(abc)",
+			act: func(t T) {
+				String(t, "abc").Equals("abc")
+			},
+			assert: func(test HelperTest) {
+				test.DidPass()
+				test.Report.IsEmpty()
+			},
+		},
+		{scenario: "String(abc).Equals(ABC)",
+			act: func(t T) {
+				String(t, "abc").Equals("ABC")
+			},
+			assert: func(test HelperTest) {
+				test.DidFail()
+				test.Report.Contains("String(abc).Equals(ABC)/string/equals")
+				test.Report.Contains([]string{
+					`wanted: "ABC"`,
+					`got   : "abc"`,
+				})
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.scenario, func(t *testing.T) {
+			tc.assert(Helper(t, tc.act))
+		})
+	}
+}

--- a/strings_test.go
+++ b/strings_test.go
@@ -52,9 +52,7 @@ func TestStrings(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.scenario, func(t *testing.T) {
-			// ARRANGE
 
-			// ACT
 			tc.exec(t)
 		})
 	}
@@ -108,8 +106,14 @@ func TestStringsTests(t *testing.T) {
 			assert: func(test HelperTest) {
 				test.DidFail()
 				test.Report.Contains([]string{
-					`wanted: [c d]`,
-					`got   : [a b]`,
+					`got:`,
+					`  [0]: "a"`,
+					`  [1]: "b"`,
+					`--`,
+					`[0] wanted: "c"`,
+					`       got: "a"`,
+					`[1] wanted: "d"`,
+					`       got: "b"`,
 				})
 			},
 		},
@@ -122,8 +126,14 @@ func TestStringsTests(t *testing.T) {
 			assert: func(test HelperTest) {
 				test.DidFail()
 				test.Report.Contains([]string{
-					`wanted: [b a]`,
-					`got   : [a b]`,
+					`got:`,
+					`  [0]: "a"`,
+					`  [1]: "b"`,
+					`--`,
+					`[0] wanted: "b"`,
+					`       got: "a"`,
+					`[1] wanted: "a"`,
+					`       got: "b"`,
 				})
 			},
 		},
@@ -136,8 +146,8 @@ func TestStringsTests(t *testing.T) {
 			assert: func(test HelperTest) {
 				test.DidFail()
 				test.Report.Contains([]string{
-					`wanted: [a b c]`,
-					`got   : [a b]`,
+					`wanted: 3 elements`,
+					`got   : 2`,
 				})
 			},
 		},
@@ -318,6 +328,40 @@ func TestStringsTests(t *testing.T) {
 					currentFilename(),
 					"DoesNotContain() invalid test: specified string is empty or consists entirely of whitespace",
 				})
+			},
+		},
+		{scenario: "Strings([abc]).ContainsMatch(abc)",
+			act: func(t T) {
+				Strings(t, "abc").ContainsMatch("abc")
+			},
+			assert: func(test HelperTest) {
+				test.DidPass()
+				test.Report.IsEmpty()
+			},
+		},
+		{scenario: "Strings([abc]).ContainsMatch(^ab$)",
+			act: func(t T) {
+				Strings(t, "abc").ContainsMatch("^ab$")
+			},
+			assert: func(test HelperTest) {
+				test.DidFail()
+				test.Report.Contains("Strings([abc]).ContainsMatch(^ab$)/strings/contains_match")
+				test.Report.Contains([]string{
+					`wanted: contains match: ^ab$`,
+					`got   : [`,
+					`abc`,
+					`]`,
+				})
+			},
+		},
+		{scenario: "Strings([abc]).ContainsMatch(invalid regex)",
+			act: func(t T) {
+				Strings(t, "abc").ContainsMatch("[")
+			},
+			assert: func(test HelperTest) {
+				test.DidFail()
+				test.Report.Contains("Strings([abc]).ContainsMatch(invalid_regex)/strings/contains_match")
+				test.Report.Contains("invalid test: ContainsMatch([): error parsing regexp: missing closing ]: `[`")
 			},
 		},
 		{scenario: "Strings([]).IsEmpty()",

--- a/testable_test.go
+++ b/testable_test.go
@@ -1,0 +1,45 @@
+package test
+
+import "testing"
+
+func TestTestable(t *testing.T) {
+	// ARRANGE
+	testcases := []struct {
+		scenario string
+		exec     func(t *testing.T)
+	}{
+		{scenario: "errorf/no args",
+			exec: func(t *testing.T) {
+				// ARRANGE
+				sut := testable[string]{}
+
+				// ACT
+				result := Helper(t, func(t *testing.T) {
+					sut.errorf(t, "error message")
+				})
+
+				// ASSERT
+				result.Report.ContainsMatch("^[\\s]+error message$")
+			},
+		},
+		{scenario: "errorf/with args",
+			exec: func(t *testing.T) {
+				// ARRANGE
+				sut := testable[string]{}
+
+				// ACT
+				result := Helper(t, func(t *testing.T) {
+					sut.errorf(t, "error message %s", "with arg")
+				})
+
+				// ASSERT
+				result.Report.ContainsMatch("^[\\s]+error message with arg$")
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.scenario, func(t *testing.T) {
+			tc.exec(t)
+		})
+	}
+}

--- a/using.go
+++ b/using.go
@@ -1,0 +1,21 @@
+package test
+
+// Using is a helper function that allows you to temporarily change the value of a variable.
+// The original value is restored when the returned function is called.
+//
+// # example
+//
+//	func TestSomething(t *testing.T) {
+//	  // ARRANGE
+//	  defer test.Using(&now, func() time.Time { return time.Date(2020,1,1,0,0,0,0,time.UTC) })()
+//
+//	  // ACT + ASSERT ...
+//
+//	  // execute some code which uses the now variable function to get the current time
+//	  // and assert that the code behaves as expected given the time is 2020-01-01
+//	}
+func Using[T any](v *T, r T) func() {
+	og := *v
+	*v = r
+	return func() { *v = og }
+}

--- a/using_test.go
+++ b/using_test.go
@@ -1,0 +1,25 @@
+package test
+
+import (
+	"testing"
+	"time"
+)
+
+func TestUsing(t *testing.T) {
+	// ARRANGE
+	var now = time.Now
+	fn := Using(&now, func() time.Time { return time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC) })
+
+	// ACT
+	result := now()
+
+	// ASSERT
+	IsTrue(t, result == time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	// ACT
+	fn()
+	result = now()
+
+	// ASSERT
+	IsFalse(t, result == time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+}


### PR DESCRIPTION
Introduces:

- test.String() for testing strings (and string representations)
- test.Using() for simple test mocks
- test.AddressOf() convenience for obtaining *T to any value T
- ContainsMatch() test added to test.Strings()
- cicd updated to use latest .reusable module release pipeline (with goreleaser.yml)